### PR TITLE
changing the JWT signing key to high-entropy random String

### DIFF
--- a/xboot-fast/src/main/java/cn/exrick/xboot/common/constant/SecurityConstant.java
+++ b/xboot-fast/src/main/java/cn/exrick/xboot/common/constant/SecurityConstant.java
@@ -1,5 +1,7 @@
 package cn.exrick.xboot.common.constant;
 
+import java.util.UUID;
+
 /**
  * @author Exrickx
  */
@@ -13,7 +15,7 @@ public interface SecurityConstant {
     /**
      * JWT签名加密key
      */
-    String JWT_SIGN_KEY = "xboot";
+    String JWT_SIGN_KEY = UUID.randomUUID().toString();
 
     /**
      * token参数头

--- a/xboot-module/xboot-core/src/main/java/cn/exrick/xboot/core/common/constant/SecurityConstant.java
+++ b/xboot-module/xboot-core/src/main/java/cn/exrick/xboot/core/common/constant/SecurityConstant.java
@@ -1,5 +1,7 @@
 package cn.exrick.xboot.core.common.constant;
 
+import java.util.UUID;
+
 /**
  * @author Exrickx
  */
@@ -13,7 +15,7 @@ public interface SecurityConstant {
     /**
      * JWT签名加密key
      */
-    String JWT_SIGN_KEY = "xboot";
+    String JWT_SIGN_KEY = UUID.randomUUID().toString();
 
     /**
      * token参数头


### PR DESCRIPTION
Setting the JWT signing key to `small-sized` `easily guessable` weak string like **xboot**  can make it vulnerable to offline brute-force attack using cracking tools like [JohnTheRipper](https://github.com/magnumripper/JohnTheRipper), [hashcat](https://github.com/hashcat/hashcat), 
[c-jwt-cracker](https://github.com/brendan-rius/c-jwt-cracker) [1] 

Therefore, the JWT signing key must be [2]
- at least 128 bits (16 characters long)
- cryptographically produced random string having high entropy

I have set the JWT signing key to a cryptographically secure random string. 

References: 
[1] [Weak Token Secret, OWASP JWT cheat-sheet](  https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.html)
[2] [Ensure Cryptographic Keys Have Sufficient Entropy RFC-8725 JSON Web Token Best Current Practices](https://tools.ietf.org/html/rfc8725#section-3.5) 